### PR TITLE
feat: accept arbitrary transaction codes using fluent style

### DIFF
--- a/src/FastACH/Builders/AchFileBuilder.cs
+++ b/src/FastACH/Builders/AchFileBuilder.cs
@@ -103,8 +103,9 @@ namespace FastACH.Builders
             /// <param name="receiverName">The name of the receiver.</param>
             /// <param name="receiverId">The receiver's identification number.</param>
             /// <param name="discretionaryData">Optional discretionary data.</param>
+            /// <param name="transactionCode">The transaction code for this entry. Defaults to 27 (checking debit)</param>
             /// <returns>The current BatchRecordBuilder instance for method chaining.</returns>
-            public BatchRecordBuilder WithDebitTransaction(decimal amount, string routingNumber, string accountNumber, string receiverName = "", string receiverId = "", string discretionaryData = "")
+            public BatchRecordBuilder WithDebitTransaction(decimal amount, string routingNumber, string accountNumber, string receiverName = "", string receiverId = "", string discretionaryData = "", uint transactionCode = 27)
             {
                 var entryDetail = new EntryDetailRecord()
                 {
@@ -115,7 +116,7 @@ namespace FastACH.Builders
                     ReceiverIdentificationNumber = receiverId,
                     ReceiverName = receiverName,
                     ReceivingDFIID = ulong.Parse(routingNumber.PadLeft(9).AsSpan().Slice(0, 8), CultureInfo.InvariantCulture),
-                    TransactionCode = 27,
+                    TransactionCode = transactionCode,
                     DiscretionaryData = discretionaryData
                 };
 
@@ -132,8 +133,9 @@ namespace FastACH.Builders
             /// <param name="receiverName">The name of the receiver.</param>
             /// <param name="receiverId">The receiver's identification number.</param>
             /// <param name="discretionaryData">Optional discretionary data.</param>
+            /// <param name="transactionCode">The transaction code for this entry. Defaults to 22 (checking credit)</param>
             /// <returns>The current BatchRecordBuilder instance for method chaining.</returns>
-            public BatchRecordBuilder WithCreditTransaction(decimal amount, string routingNumber, string accountNumber, string receiverName = "", string receiverId = "", string discretionaryData = "")
+            public BatchRecordBuilder WithCreditTransaction(decimal amount, string routingNumber, string accountNumber, string receiverName = "", string receiverId = "", string discretionaryData = "", uint transactionCode = 22)
             {
                 var entryDetail = new EntryDetailRecord()
                 {
@@ -144,7 +146,7 @@ namespace FastACH.Builders
                     ReceiverIdentificationNumber = receiverId,
                     ReceiverName = receiverName,
                     ReceivingDFIID = ulong.Parse(routingNumber.PadLeft(9).AsSpan().Slice(0, 8), CultureInfo.InvariantCulture),
-                    TransactionCode = 22,
+                    TransactionCode = transactionCode,
                     DiscretionaryData = discretionaryData
                 };
 

--- a/tests/FastACH.Tests/Builders/AchFileBuilderTests.cs
+++ b/tests/FastACH.Tests/Builders/AchFileBuilderTests.cs
@@ -410,5 +410,127 @@ namespace FastACH.Tests.Builders
             achFile.BatchRecordList[0].TransactionRecords[1].EntryDetail.DiscretionaryData.Should().Be("D2");
             achFile.BatchRecordList[0].TransactionRecords[1].AddendaRecords.Should().BeEmpty();
         }
+
+        [Fact]
+        public void WithDebitTransaction_CustomTransactionCode_ShouldUseSavingsDebit()
+        {
+            // Arrange
+            var expectedAmount = 75.25m;
+            var expectedRoutingNumber = "123456789";
+            var expectedAccountNumber = "987654321";
+            var expectedReceiverName = "Jane Smith";
+            var expectedReceiverId = "ID456";
+            var expectedDiscretionaryData = "XY";
+
+            // Act
+            var achFile = new AchFileBuilder()
+                .With("123456789", "987654321")
+                .WithBatch(batch => batch
+                    .With("1234567890", "12345678", "PAYROLL", "My Company")
+                    .WithDebitTransaction(
+                        amount: expectedAmount,
+                        routingNumber: expectedRoutingNumber,
+                        accountNumber: expectedAccountNumber,
+                        receiverName: expectedReceiverName,
+                        receiverId: expectedReceiverId,
+                        discretionaryData: expectedDiscretionaryData,
+                        transactionCode: 37))
+                .Build();
+
+            // Assert
+            var transaction = achFile.BatchRecordList[0].TransactionRecords[0];
+            transaction.EntryDetail.Amount.Should().Be(expectedAmount);
+            transaction.EntryDetail.DFIAccountNumber.Should().Be(expectedAccountNumber);
+            transaction.EntryDetail.ReceiverName.Should().Be(expectedReceiverName);
+            transaction.EntryDetail.ReceiverIdentificationNumber.Should().Be(expectedReceiverId);
+            transaction.EntryDetail.DiscretionaryData.Should().Be(expectedDiscretionaryData);
+            transaction.EntryDetail.TransactionCode.Should().Be(37u); // Savings Debit
+            transaction.EntryDetail.AddendaRecordIndicator.Should().BeFalse();
+        }
+
+        [Fact]
+        public void WithCreditTransaction_CustomTransactionCode_ShouldUseSavingsCredit()
+        {
+            // Arrange
+            var expectedAmount = 100.50m;
+            var expectedRoutingNumber = "123456789";
+            var expectedAccountNumber = "987654321";
+            var expectedReceiverName = "John Doe";
+            var expectedReceiverId = "ID123";
+            var expectedDiscretionaryData = "DD";
+
+            // Act
+            var achFile = new AchFileBuilder()
+                .With("123456789", "987654321")
+                .WithBatch(batch => batch
+                    .With("1234567890", "12345678", "PAYROLL", "My Company")
+                    .WithCreditTransaction(
+                        amount: expectedAmount,
+                        routingNumber: expectedRoutingNumber,
+                        accountNumber: expectedAccountNumber,
+                        receiverName: expectedReceiverName,
+                        receiverId: expectedReceiverId,
+                        discretionaryData: expectedDiscretionaryData,
+                        transactionCode: 32))
+                .Build();
+
+            // Assert
+            var transaction = achFile.BatchRecordList[0].TransactionRecords[0];
+            transaction.EntryDetail.Amount.Should().Be(expectedAmount);
+            transaction.EntryDetail.DFIAccountNumber.Should().Be(expectedAccountNumber);
+            transaction.EntryDetail.ReceiverName.Should().Be(expectedReceiverName);
+            transaction.EntryDetail.ReceiverIdentificationNumber.Should().Be(expectedReceiverId);
+            transaction.EntryDetail.DiscretionaryData.Should().Be(expectedDiscretionaryData);
+            transaction.EntryDetail.TransactionCode.Should().Be(32u); // Savings Credit
+            transaction.EntryDetail.AddendaRecordIndicator.Should().BeFalse();
+        }
+
+        [Fact]
+        public void WithBatch_MixedCheckingAndSavingsTransactions_ShouldSetCorrectCodes()
+        {
+            // Act
+            var achFile = new AchFileBuilder()
+                .With("123456789", "987654321")
+                .WithBatch(batch => batch
+                    .With("1234567890", "12345678", "BILLPAY", "My Company")
+                    .WithDebitTransaction(100.00m, "123456789", "111111111",
+                        receiverName: "Checking Customer")
+                    .WithDebitTransaction(200.00m, "123456789", "222222222",
+                        receiverName: "Savings Customer",
+                        transactionCode: 37)
+                    .WithCreditTransaction(300.00m, "123456789", "333333333",
+                        receiverName: "Checking Vendor")
+                    .WithCreditTransaction(400.00m, "123456789", "444444444",
+                        receiverName: "Savings Vendor",
+                        transactionCode: 32))
+                .Build();
+
+            // Assert
+            var transactions = achFile.BatchRecordList[0].TransactionRecords;
+            transactions.Should().HaveCount(4);
+            transactions[0].EntryDetail.TransactionCode.Should().Be(27u); // Checking Debit
+            transactions[1].EntryDetail.TransactionCode.Should().Be(37u); // Savings Debit
+            transactions[2].EntryDetail.TransactionCode.Should().Be(22u); // Checking Credit
+            transactions[3].EntryDetail.TransactionCode.Should().Be(32u); // Savings Credit
+        }
+
+        [Fact]
+        public void WithDebitTransaction_PrenoteTransactionCode_ShouldSetCorrectCode()
+        {
+            // Act
+            var achFile = new AchFileBuilder()
+                .With("123456789", "987654321")
+                .WithBatch(batch => batch
+                    .With("1234567890", "12345678", "PAYROLL", "My Company")
+                    .WithDebitTransaction(0.00m, "123456789", "987654321",
+                        receiverName: "Prenote Test",
+                        transactionCode: 28))
+                .Build();
+
+            // Assert
+            var transaction = achFile.BatchRecordList[0].TransactionRecords[0];
+            transaction.EntryDetail.TransactionCode.Should().Be(28u); // Checking Debit Prenote
+            transaction.EntryDetail.Amount.Should().Be(0.00m);
+        }
     }
 }


### PR DESCRIPTION
Add the ability to specify arbitrary transaction codes while using the library in the fluent style. This enables Builder style coding to debit or credit savings accounts, prenotes and other types of supported ACH transaction codes.

Keep the old behaviors as the default so no one is surprised.

Add tests to ensure changes work correctly and do not cause regressions in other parts of the library.